### PR TITLE
Rename `index.ts` to `main.ts` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ Release:
 - Copy .js from `/dist`
 
 ### Note
-- Keep the script definition object (that contains the `run`, `getScriptManifest`, and `getDefaultParameters` funcs) in the `index.ts` file as it's important those function names don't get minimized.
+- Keep the script definition object (that contains the `run`, `getScriptManifest`, and `getDefaultParameters` funcs) in the `main.ts` file as it's important those function names don't get minimized.
 - Edit the `"scriptOutputName"` property in `package.json` to change the filename of the outputted script.


### PR DESCRIPTION
This renames a mention of `index.ts` to `main.ts`, because the file in src is called `main.ts` in the current version of the template