### PR TITLE
Add title param to message

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ const script: Firebot.CustomScript<Params> = {
         default: "Hello World!",
         description: "Message",
         secondaryDescription: "Enter a message here",
+        title: "Hello!",
       },
     };
   },


### PR DESCRIPTION
The project doesn't pass typechecking by default because the `message` object needs to contain a `title` field. Fix.